### PR TITLE
bosh/spec.go: fix network struct to work on GCP

### DIFF
--- a/bosh/spec.go
+++ b/bosh/spec.go
@@ -30,11 +30,10 @@ type pkg struct {
 }
 
 type network struct {
-	CloudProperties map[string]string `json:"cloud_properties"`
-	Default         []string          `json:"default"`
-	Gateway         string            `json:"gateway"`
-	IP              string            `json:"ip"`
-	Netmask         string            `json:"netmask"`
+	Default []string `json:"default"`
+	Gateway string   `json:"gateway"`
+	IP      string   `json:"ip"`
+	Netmask string   `json:"netmask"`
 }
 
 func loadSpec(path string) (spec, error) {


### PR DESCRIPTION
CloudProperties key was not used. Furthermore, with GCP CPI there are values
in cloud_properties that are not strings, e.g. ephemeral_external_ip.

Once merged, this will need to be bumped in `weave-scope-release` also.

Thanks!